### PR TITLE
[PI Sprint 25/26] [Feature] - Gravity Based Roll Pitch

### DIFF
--- a/include/taisei/robot_wrapper/robot_wrapper.hpp
+++ b/include/taisei/robot_wrapper/robot_wrapper.hpp
@@ -32,7 +32,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 #include "Eigen/Geometry"
-#include "keisan/angle.hpp"
+#include "keisan/keisan.hpp"
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tachimawari_interfaces/msg/current_joints.hpp"
@@ -60,7 +60,7 @@ public:
     void update_kinematics();
     void get_q_indexes();
     void update_joint_positions(u_int8_t joint_id, double position);
-    void update_orientation(const keisan::Angle<double> & roll, const keisan::Angle<double> & pitch, const keisan::Angle<double> & yaw);
+    void update_orientation(const keisan::Point3 & gravity, const keisan::Angle<double> & yaw);
     void get_joint_dictionary();
     void get_config();
     std::vector<geometry_msgs::msg::TransformStamped> get_all_transforms(const rclcpp::Time& stamp);

--- a/src/taisei/node/taisei_node.cpp
+++ b/src/taisei/node/taisei_node.cpp
@@ -29,11 +29,11 @@ namespace taisei
 
 
 RobotWrapperNode::RobotWrapperNode(const rclcpp::Node::SharedPtr & node, const std::string & model_directory) : node(node)
-{   
+{
     robot_wrapper = std::make_shared<RobotWrapper>(model_directory);
     tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node);
 
-    joint_subscriber = node->create_subscription<tachimawari_interfaces::msg::CurrentJoints>("/joint/current_joints", 10, 
+    joint_subscriber = node->create_subscription<tachimawari_interfaces::msg::CurrentJoints>("/joint/current_joints", 10,
     [this](tachimawari_interfaces::msg::CurrentJoints::SharedPtr msg) -> void {
         for(const auto& joint : msg->joints){
             robot_wrapper->update_joint_positions(joint.id, joint.position);
@@ -42,10 +42,13 @@ RobotWrapperNode::RobotWrapperNode(const rclcpp::Node::SharedPtr & node, const s
 
     orientation_subscriber = node->create_subscription<kansei_interfaces::msg::Status>("/measurement/status", 10,
     [this](kansei_interfaces::msg::Status::SharedPtr msg) -> void {
-        auto roll = keisan::make_degree(msg->orientation.roll);
-        auto pitch = keisan::make_degree(msg->orientation.pitch);
         auto yaw = keisan::make_degree(msg->orientation.yaw);
-        robot_wrapper->update_orientation(roll, pitch, yaw);
+        auto gravity = keisan::Point3(
+            msg->gravity.x,
+            msg->gravity.y,
+            msg->gravity.z);
+
+        robot_wrapper->update_orientation(gravity, yaw);
     });
 
     node_timer = node->create_wall_timer(8ms, [this]() { this->broadcast_tf_frames();});

--- a/src/taisei/robot_wrapper/robot_wrapper.cpp
+++ b/src/taisei/robot_wrapper/robot_wrapper.cpp
@@ -87,25 +87,37 @@ void RobotWrapper::update_joint_positions(u_int8_t joint_id, double position_deg
 }
 
 
-void RobotWrapper::update_orientation(
-    const keisan::Angle<double>& roll,
-    const keisan::Angle<double>& pitch,
-    const keisan::Angle<double>& yaw)
+// Update robot orientation using gravity (roll & pitch) and yaw
+void RobotWrapper::update_orientation(const keisan::Point3& gravity, const keisan::Angle<double>& yaw)
 {
-    Eigen::Quaterniond imu_q =
-        Eigen::AngleAxisd(yaw.radian(),   Eigen::Vector3d::UnitZ()) *
-        Eigen::AngleAxisd(pitch.radian(), Eigen::Vector3d::UnitY()) *
-        Eigen::AngleAxisd(roll.radian(),  Eigen::Vector3d::UnitX());
+    Eigen::Vector3d g_body{
+        -gravity.y,
+        gravity.x,
+        gravity.z
+    };
 
-    imu_q.normalize();
+    if (g_body.norm() < 1e-6)
+        return;
 
-    body_quaterniond = imu_q;
+    g_body.normalize();
+
+    Eigen::Quaterniond level_q;
+    level_q.setFromTwoVectors(g_body, Eigen::Vector3d::UnitZ());
+
+    Eigen::Quaterniond yaw_q(
+        Eigen::AngleAxisd(yaw.radian(), Eigen::Vector3d::UnitZ())
+    );
+
+    Eigen::Quaterniond final_q = yaw_q * level_q;
+    final_q.normalize();
+
+    body_quaterniond = final_q;
 
     if (q.size() >= 7) {
-        q[3] = imu_q.x();
-        q[4] = imu_q.y();
-        q[5] = imu_q.z();
-        q[6] = imu_q.w();
+        q[3] = final_q.x();
+        q[4] = final_q.y();
+        q[5] = final_q.z();
+        q[6] = final_q.w();
     }
 }
 


### PR DESCRIPTION
## Jira Link: 

## Description

Implement gravity vector for roll and pitch estimation for body TF.
The previous implementation relied on IMU RPY values, which are highly dependent on correct posture during sensor reset.

## Type of Change

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.